### PR TITLE
Use proton-exp-{version} instead of proton-{version}-exp naming scheme

### DIFF
--- a/build_wine.sh
+++ b/build_wine.sh
@@ -240,6 +240,7 @@ elif [ "$WINE_BRANCH" = "proton" ]; then
 		BUILD_NAME=proton-exp-"${WINE_VERSION}"
 	else
 		BUILD_NAME=proton-"${WINE_VERSION}"
+	fi
 else
 	if [ "${WINE_VERSION}" = "git" ]; then
 		git clone https://gitlab.winehq.org/wine/wine.git wine

--- a/build_wine.sh
+++ b/build_wine.sh
@@ -236,7 +236,10 @@ elif [ "$WINE_BRANCH" = "proton" ]; then
 	fi
 
 	WINE_VERSION="$(cat wine/VERSION | tail -c +14)-$(git -C wine rev-parse --short HEAD)"
-	BUILD_NAME=proton-"${WINE_VERSION}"
+	if [[ "${PROTON_BRANCH}" == "experimental_"* ]]; then
+		BUILD_NAME=proton-exp-"${WINE_VERSION}"
+	else
+		BUILD_NAME=proton-"${WINE_VERSION}"
 else
 	if [ "${WINE_VERSION}" = "git" ]; then
 		git clone https://gitlab.winehq.org/wine/wine.git wine


### PR DESCRIPTION
Please correct me if this isn't the right place to set the new name, as I searched in the `build_wine.sh` file and did not see were the `-exp` currently comes from.

Partially fixes #108